### PR TITLE
fix: support multiple types for default_value

### DIFF
--- a/ibm_catalog-schema.json
+++ b/ibm_catalog-schema.json
@@ -339,7 +339,7 @@
                                                 "type": "string"
                                             },
                                             "default_value": {
-                                                "type": "string"
+                                                "type": ["string", "number", "integer", "boolean", "array", "object"]
                                             },
                                             "description": {
                                                 "type": "string"


### PR DESCRIPTION
https://github.com/IBM/deployable-architecture-builder-vscode-extension/issues/8